### PR TITLE
Fix `get_open_close()` for crayon 1.4.2

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -41,7 +41,7 @@ get_open_close <- function(clr) {
   if (crayon_is_r_color(clr)) {
     o_c <- crayon_style_from_r_color(clr,
       bg = FALSE, num_colors = num_colors, grey = FALSE
-    )
+    )[c("open", "close")]
   } else {
     stop("Don't know how to handle non-R color.")
   }


### PR DESCRIPTION
Ideally one would use `start()` and `finish()` to
get the opening and closing sequences, but this is
a good fix, I don't think that crayon would break this
in the future.

Without this fix a multicolor test case fails:

```
Package: multicolor
Check: tests
New result: ERROR
    Running ‘testthat.R’ [12s/13s]
  Running the tests in ‘tests/testthat.R’ failed.
  Complete output:
    > library(testthat)
    > library(multicolor)
    Colors cannot be applied in this environment. Please use another application, such as RStudio or a color-enabled terminal.
    Colors cannot be applied in this environment. Please use another application, such as RStudio or a color-enabled terminal.
    >
    > test_check("multicolor")
    ══ Skipped tests ═══════════════════════════════════════════════════════════════
    • use_color() is not TRUE (1)

    ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Failure (test-multicolor.R:224:3): utils ────────────────────────────────────
    get_open_close("white") not equal to list(open = "\033[37m", close = "\033[39m").
    Length mismatch: comparison on first 2 components

    [ FAIL 1 | WARN 1 | SKIP 1 | PASS 29 ]
    Error: Test failures
    Execution halted
```