### PR TITLE
Use `as.vector()` not `as_vector()` to drop matrix class

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -122,7 +122,7 @@ add_css <- function(txt, font_fam = "Monaco") {
 nix_first_newline <- function(s) {
   newline_ix <- s %>%
     stringr::str_locate("\n") %>%
-    purrr::as_vector() %>%
+    as.vector() %>%
     dplyr::first()
 
   if (is.na(newline_ix)) {


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

I think you were expecting `purrr::as_vector()` to turn a matrix into a vector. It actually doesn't do that, surprisingly; it mainly just unlists lists. You really wanted `as.vector()` here. It happened to work before because `first()` was turning your matrix into a vector and plucking off the first element of the matrix, but it now keeps the first row.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package to CRAN ahead of time! Thanks!